### PR TITLE
v2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Below is a list of all available parameters and what they do.. You can use **mul
 > Valid image extensions are `webp`, `png`, `jpg`, `jpeg` & `gif`
 
 ###### text `<quotes>`&emsp;&emsp;<samp>aliases: `txt`, `contains`</samp>
-> Deletes messages with plain text *(no embed, no images, no files, etc..)*</br>
+> Deletes messages with plain text, commands and emojis *(no embeds, no images, no files, etc..)*</br>
 > If quotes are provided, then only messages containing the quotes will be targeted*</br>Valid quotes are any word/sentence enclosed in quotation marks, example `"hello world"`
 
 ###### commands `<prefixes>`&emsp;&emsp;<samp>aliases: `cmds`, `startsWith`</samp>

--- a/app.js
+++ b/app.js
@@ -27,20 +27,32 @@ const init = async function() {
 }
 
 client.on('debug', function(d) {
-    client.shard.send({ type: 'debug', message: d });
+    try {
+        client.shard.send({ type: 'debug', message: d });
+    } catch (e) {
+        console.error(e);
+    }
 });
 
 client.on('warn', function(e) {
-    client.shard.send({ type: 'warn', message: e });
+    try {
+        client.shard.send({ type: 'warn', message: e });
+    } catch (e) {
+        console.error(e);
+    }
 });
 
 client.on('error', function(e) {
-    if (client.options.errorLogChannel) {
-        let errorEmbed = client._constructErrorEmbed(e);
-        client.channels.fetch(client.options.errorLogChannel).then(channel => { if(channel) channel.send('', errorEmbed) });
-    }
+    try {
+        if (client.options.errorLogChannel) {
+            let errorEmbed = client._constructErrorEmbed(e);
+            client.channels.fetch(client.options.errorLogChannel).then(channel => { if(channel) channel.send('', errorEmbed) });
+        }
 
-    client.shard.send({ type: 'error', message: e.stack });
+        client.shard.send({ type: 'error', message: e.stack || e });
+    } catch (e) {
+        console.error(e);
+    }
 });
 
 client.on('ready', function() {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "commandcleanup",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Discord.js CommandCleanup bot",
   "main": "./index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "keywords": [
     "discord.js",
     "commandcleanup",

--- a/src/client/commands/cleanup.js
+++ b/src/client/commands/cleanup.js
@@ -331,7 +331,7 @@ class CleanupCommand extends BaseCommand {
                         if (filters.length == 0) {
                             if (options.before || options.after || options.mentions) filters = new Filters(Filters.ALL).freeze().bitfield;
                             else if (options.limit && (!options.before && !options.after && !options.mentions && filters !== Filters.ALL)) errors.push('Providing a limit by itself no longer works, please provide another parmameter to specify the content to delete. Example, ' + `\`.cleanup ${options.limit} all\``);
-                            else errors.push('No parameters recognised, parameters are required.');
+                            else errors.push(`No parameters recognised, parameters are required.\nFor a list of parameters check out our [GitHub Page](https://github.com/FatAussieFatBoy/CommandCleanup#parameters)`);
                         }
 
                         if (errors.length > 0) {
@@ -365,7 +365,7 @@ class CleanupCommand extends BaseCommand {
                         this.client.emit('error', e);
                     });
                 } else {
-                    messages.push(msg.direct('', errorEmbed({ title: 'Cleanup Parameter Error', description: `The cleanup command requires parameters to function, for a list of available parameters visit our [DiscordBots Page](https://discordbots.org/bot/420013638468894731)` })).then(m => m.delete({ timeout: 30000, reason: 'Automated deletion.' })));
+                    messages.push(msg.direct('', errorEmbed({ title: 'Cleanup Parameter Error', description: `The cleanup command requires parameters to function, for a list of available parameters visit our [GitHub Page](https://github.com/FatAussieFatBoy/CommandCleanup#parameters)` })).then(m => m.delete({ timeout: 30000, reason: 'Automated deletion.' })));
                     return messages;
                 }
             }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -42,6 +42,13 @@ exports.RegularExpressions = {
     symbols_and_quotes: new RegExp(/([^\w\s"',-]+(\w)*|"((?=[^"])[^"]+)"|'((?=[^'])[^']+)')+?(?=,|$|\s*)/gm),
 
     /**
+     * Regular Expression that matches emojis
+     * @type {RegExp}
+     */
+
+    emojis: new RegExp(/(<(a)?:[^:<>]+:([0-9]+)>)/gm),
+
+    /**
      * Regular Expression that matches links
      * @type {RegExp}
      */

--- a/src/util/Filters.js
+++ b/src/util/Filters.js
@@ -59,6 +59,8 @@ class Filter extends BitField {
  * * `COMMAND` (the message matches the command regex)
  * * `FILE` (the message contains an attachment other than an image)
  * * `IMAGE` (the message contains an image)
+ * * `EMOJI` (the message contains at least one emoji)
+ * * `DISCORD` (the message is a discord system message)
  * @type {Object}
  */
 
@@ -76,8 +78,9 @@ Filter.FLAGS = {
 	COMMAND: 1 << 9,
 	FILE: 1 << 10,
 	IMAGE: 1 << 11,
+	EMOJI: 1 << 12,
 
-	DISCORD: 1 << 12
+	DISCORD: 1 << 13,
 };
 
 /**


### PR DESCRIPTION
Attempted to fix error on internal server with ERR_IPC_CHANNE_CLOSED error.

Updated cleanup error messages to include the readme parameters header hyperlink.

Changes to the cleanup "commands" parameter,
- Fixed messages that start with emojis being deleted.
- Fixed messages that didn't start with a command being recognised as a command.

Improved text channel send method to deconstruct only if the channel denies sending embeds rather than allowing them. (allows for neutral positions inside the channels permissions)

Added new "EMOJI" type to the message filters and a new emoji regular expression.